### PR TITLE
Specify radix for quantity parsing in handleAction

### DIFF
--- a/components/Portfolio.js
+++ b/components/Portfolio.js
@@ -16,7 +16,7 @@ export default function Portfolio({ currentPrices }) {
   const handleAction = () => {
     if (!selectedStock || !quantity) return;
     
-    const qty = parseInt(quantity);
+    const qty = parseInt(quantity, 10);
     const price = currentPrices[selectedStock] || 0;
     
     if (action === 'buy') {


### PR DESCRIPTION
## Summary
- ensure `parseInt` in portfolio action handler uses base 10 for reliable quantity parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `node -e "const currentPrices={DEWA:100};let calls=[];function addToPortfolio(symbol,qty,price){calls.push({type:'buy',symbol,qty,price});}const selectedStock='DEWA';const quantity='08';const action='buy';const qty=parseInt(quantity,10);const price=currentPrices[selectedStock]||0;if(action==='buy'){addToPortfolio(selectedStock,qty,price);}console.log(calls);"`


------
https://chatgpt.com/codex/tasks/task_e_689dd765b3d483338f29acd275603878