### PR TITLE
feat: add Arabic font to PDF report

### DIFF
--- a/components/StockReportPDF.js
+++ b/components/StockReportPDF.js
@@ -1,11 +1,17 @@
-import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+import { Document, Page, Text, View, StyleSheet, Font } from '@react-pdf/renderer';
 import { format } from 'date-fns';
 import { ar } from 'date-fns/locale';
+
+// Register Arabic font for proper text rendering
+Font.register({
+  family: 'Amiri',
+  src: 'https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Regular.ttf',
+});
 
 const styles = StyleSheet.create({
   page: {
     padding: 30,
-    fontFamily: 'Arial',
+    fontFamily: 'Amiri',
   },
   header: {
     textAlign: 'center',


### PR DESCRIPTION
## Summary
- register Arabic Amiri font for React PDF generation
- switch PDF report styling to use Amiri for proper Arabic rendering

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `pdftotext test.pdf -`

------
https://chatgpt.com/codex/tasks/task_e_689dd763fae88333afa04bc996bc98b3