### PR TITLE
Use dynamic imports for chart components

### DIFF
--- a/components/StockCard.js
+++ b/components/StockCard.js
@@ -1,5 +1,7 @@
 import { useRouter } from 'next/router';
-import LineChart from './LineChart';
+import dynamic from 'next/dynamic';
+
+const LineChart = dynamic(() => import('./LineChart'), { ssr: false });
 
 export default function StockCard({ name, data }) {
   const router = useRouter();

--- a/pages/stocks/[symbol].js
+++ b/pages/stocks/[symbol].js
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import dynamic from 'next/dynamic';
 import Navigation from '../../components/Navigation';
-import AdvancedChart from '../../components/AdvancedChart';
 import TechnicalIndicators from '../../components/TechnicalIndicators';
 import DownloadReport from '../../components/DownloadReport';
+
+const AdvancedChart = dynamic(() => import('../../components/AdvancedChart'), { ssr: false });
 
 export default function StockDetail() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- Lazy-load `LineChart` in stock cards with `next/dynamic` and SSR disabled
- Lazy-load `AdvancedChart` on stock detail page to prevent server-side rendering issues

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires configuration prompt)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689dd76287c483338d9f25425f57a210