### PR TITLE
Handle fetch errors on stock detail page

### DIFF
--- a/pages/stocks/[symbol].js
+++ b/pages/stocks/[symbol].js
@@ -19,7 +19,10 @@ export default function StockDetail() {
           setStockData(data[symbol.toUpperCase()]);
           setLoading(false);
         })
-        .catch(error => console.error('Error fetching data:', error));
+        .catch(error => {
+          console.error('Error fetching data:', error);
+          setLoading(false);
+        });
     }
   }, [symbol]);
 


### PR DESCRIPTION
## Summary
- stop infinite loading when stock data fetch fails by clearing loading state in catch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive setup)*
- `node test-error.js` *(fails: unable to download Playwright browser)*

------
https://chatgpt.com/codex/tasks/task_e_689dd760edb0833390b7819ef271707f